### PR TITLE
Added a note for running Jupyter notebooks on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,14 @@ The container comes pre-installed with iPython and iTorch Notebooks, and you can
 
 However, you still need to start the Notebook inside the container to be able to access it from the host. You can either do this from the container terminal by executing `jupyter notebook` or you can pass this command in directly while spinning up your container using the `docker run -it -p 8888:8888 -p 6006:6006 floydhub/dl-docker:cpu jupyter notebook` CLI. The Jupyter Notebook has both Python (for TensorFlow, Caffe, Theano, Keras, Lasagne) and iTorch (for Torch) kernels.
 
+Note: If you are setting the notebook on Windows, you will need to first determine the IP address of your Docker container. This command on the Docker command-line provides the IP address
+```bash
+docker-machine ip default
+> <IP-address>
+```
+```default``` is the name of the container provided by default to the container you will spin. 
+On obtaining the IP-address, run the docker as per the [instructions](#running-the-docker-image-as-a-container) provided and start the Jupyter notebook as [described above](#jupyter-notebooks). Then accessing ```http://<IP-address>:<host-port>``` on your host's browser should show you the notebook.
+
 ### Data Sharing
 See [Docker container persistence](#docker-container-persistence). 
 Consider this: You have a script that you've written on your host machine. You want to run this in the container and get the output data (say, a trained model) back into your host. The way to do this is using a [Shared Volumne](#docker-container-persistence). By passing in the `-v /sharedfolder/:/root/sharedfolder` to the CLI, we are sharing the folder between the host and the container, with persistence. You could copy your script into `/sharedfolder` folder on the host, execute your script from inside the container (located at `/root/sharedfolder`) and write the results data back to the same folder. This data will be accessible even after you kill the container.


### PR DESCRIPTION
127.0.0.1 does not work when attempting to run this on Windows.
There's a separate command which helps determine the IP-address assigned to the Docker container. 
This address helps access the Jupyter notebook.